### PR TITLE
(maint) Add explanation of algebra notation and link to it where used

### DIFF
--- a/language/intro.md
+++ b/language/intro.md
@@ -96,3 +96,43 @@ ASequenceOfNames
   ;
   
 ```
+### Set Algebra Notation
+
+Algebra notation is used in the specification to describe the operations on
+types as well as other logical constructs. Here is a repetition of the set theory notations
+used in this specification:
+
+`X` is *member of* (the set `Y`) (can be read as `exists in`)
+
+    X ∈ Y
+
+`X` is *not member of* (the set `Y`) (can be read as `exists in`)
+
+    X ∉ Y
+
+The *union* of `X` and `Y` (all that are in `X`, in `Y`, or in both)
+
+    X ∪ Y
+    
+The intersection of `X` and `Y` (all that are in both `X` and `Y`)
+
+    X ∩ Y
+    
+Implies, gives, produces (depending on context)
+
+    →
+    
+The empty set
+
+    ∅
+
+    
+#### Examples:
+
+The union of the type Integer and the type Float is Numeric:
+
+    Integer ∪ Float → Numeric
+
+This means that if there is a collection of objects that consist of integers and float
+(but no instances of any other type), then the collection is of
+`Collection[Numeric]` types.

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -163,6 +163,10 @@ may appear more than once in the hierarchy, typically with different narrower ty
 
 In addition to these types, a Qualified Reference that does not represent any of the other types is interpreted as `Resource[the_qualified_reference]` (e.g. `File` is shorthand notation for `Resource[File]` / `Resource[file]`).
 
+The descriptions use [Set Algebra Notation][1] to describe properties / operations on types.
+
+[1]: intro.md#set-algebra-notation
+
 Runtime Types
 ---
 


### PR DESCRIPTION
This adds a section in the into.md document about the notation used in the type algrebra. This because readers may not be familiar with union/intersection, etc. notation, or need a refresh.
