### PR TITLE
Add type declaration to attritute Test/Name in ecore model

### DIFF
--- a/models/LanguageSpec.ecore
+++ b/models/LanguageSpec.ecore
@@ -16,7 +16,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="Test">
     <eStructuralFeatures xsi:type="ecore:EReference" name="expectations" upperBound="-1"
         eType="#//Expectation"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="comment" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="specReference" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">


### PR DESCRIPTION
The ecore:EAttribute for the name feature of the Test class was
missing its type. This commit sets the type to EString.
