### PR TITLE
(PUP-3117) Update spec about resource expressions

### DIFF
--- a/language/catalog_expressions.md
+++ b/language/catalog_expressions.md
@@ -247,7 +247,10 @@ elsewhere via *exported resource collection*.
   type for that attribute. The values set this way are subject to the same rules as if
   the `key => value` entries in the hash had been made directly in the resource body (i.e. they
   must be unique).
-  
+
+* A `* =>` may appear anywhere in the list of attribute operations, but may only be used once per
+  resource body.
+
 * A body with a title of `Default` type defines a *local default*, other bodies in the same resource
   expression will use the attribute operations for this body as default values.
   


### PR DESCRIPTION
This fixes many issues in the spec regarding resource expressions.
While the jury is still out on PUP-3117 regarding what the operator for \* => is called, the behavior is still the same, and what was in the spec is wrong. (I.e. it is easier to modify the spec to comply with the decision in PUP-3117 once is made after this PR is merged - it will need to be updated with these changes anyway; albeit with further changes if the operator, or semantics change).
