### PR TITLE
(PUP-4026) Add facter's facts.d

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -39,6 +39,9 @@ puppet-agent
         mco@                              -> /opt/puppetlabs/puppet/bin/mco
         puppet@                           -> /opt/puppetlabs/puppet/bin/puppet
 
+    /opt/puppetlabs/facter
+        facts.d                           # external facts directory (not pluginsync'ed)
+
     /opt/puppetlabs/mcollective/
         plugins
 
@@ -60,7 +63,7 @@ puppet-agent
             client_data                   # :client_datadir
             clientbucket                  # :clientbucketdir
             devicedir                     # :devices
-            facts.d                       # :pluginfactdest
+            facts.d                       # :pluginfactdest (pluginsync'ed)
             lib                           # :libdir
             facts                         # used to generate :factpath
             puppet-module                 # :module_working_dir


### PR DESCRIPTION
Previously we only specified the location that puppet pluginsyncs
external facts to. Unfortunately, facter's facts.d directory was not
specified.

This commit adds facter's facts.d directory to
/opt/puppetlabs/facter/facts.d. It is not located in
/opt/puppetlabs/puppet, because this facts.d directory is a facter
implementation detail, and puppet has no knowledge of it.