### PR TITLE
(maint) Clarify puppetserver log and pid locations

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -280,6 +280,13 @@ These sections describe other Puppet packages that rely on puppet-agent to creat
                 server_datadir            # :server_data
                 yaml                      # :yamldir
 
+    /var/log/puppetlabs                   # :logdir                      /var/lib/puppet/log
+        puppetserver/                     # writeable by puppetserver
+            puppetserver.log
+
+    /var/run/puppetlabs                   # :rundir                      /var/lib/puppet/run
+        puppetserver/                     # writeable by puppetserver
+            puppetserver.pid
 
 # Notes
 


### PR DESCRIPTION
Without this patch the location of the puppetserver log files and pid files are
ambiguous.  The location inferred by the locations of the agent.pid and
puppet.log are problematic because puppetserver does not run as root and as
such will not be able to create new files in `/var/run/puppetlabs` and
`/var/log/puppetlabs`.

This pull request proposes puppetserver writable directories of
`/var/log/puppetlabs/puppetserver/` and `/var/run/puppetlabs/puppetserver/`