### PR TITLE
Remove reference to a separate service

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -319,8 +319,8 @@ The package will install a service named `puppetserver`, create a
 
 This is a compatibility package using passenger to serve a ruby based puppetmaster.
 
-The package will install a service named `puppetmaster`, create a
-`puppet` user and group, and run the service as the `puppet` user.
+The package will install passenger in conjunction with Apache, create a
+`puppet` user and group, and run the instance as the `puppet` user.
 
     /opt/puppetlabs/server *              # serverside apps live underneath
         data *


### PR DESCRIPTION
Previously the specification said we would create a new service. We are
actually just going to rely upon a stock Apache installations and build
passenger within those constraints.