### PR TITLE
(PUP-4194) Isolate puppet's logdir

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -112,9 +112,10 @@ The files annotated by an '*' indicate that they are created by package installa
             vim *
         ssl *
 
-    /var/log/puppetlabs *                 # :logdir                      /var/lib/puppet/log
-        puppet.log                        # not enabled by default
+    /var/log/puppetlabs *
         mcollective.log
+        puppet *                          # :logdir                      /var/lib/puppet/log
+            puppet.log                    # not enabled by default
 
     /var/run/puppetlabs *                 # :rundir                      /var/lib/puppet/run
         agent.pid                         # :pidfile
@@ -307,12 +308,12 @@ The package will install a service named `puppetserver`, create a
                 server_data               # :server_datadir
                 yaml                      # :yamldir
 
-    /var/log/puppetlabs                   # :logdir                      /var/lib/puppet/log
-        puppetserver/                     # writeable by puppetserver
+    /var/log/puppetlabs
+        puppetserver *                    # writeable by puppetserver
             puppetserver.log
 
     /var/run/puppetlabs                   # :rundir                      /var/lib/puppet/run
-        puppetserver/                     # writeable by puppetserver
+        puppetserver                      # writeable by puppetserver
             puppetserver.pid
 
 # puppetmaster
@@ -330,7 +331,7 @@ The package will install a service named `puppetmaster`, create a
                 server_data               # :server_datadir
                 yaml                      # :yamldir
 
-    /var/log/puppetlabs                   # :logdir                      /var/lib/puppet/log
+    /var/log/puppetlabs
         puppetmaster *                    # writeable by puppetmaster
             puppetmaster.log
 


### PR DESCRIPTION
When puppet executes as root, it sets permissions for file-based
settings to either `puppet:puppet` or `root:root` depending on whether
the puppet user and group exist or not.

Previously, puppet's `logdir` setting was `/var/log/puppetlabs`. If the
puppet user didn't exist, then puppet would set permissions to
root:root with mode 0750. If you later installed `puppetserver`, it
would create its log directory in `$logdir/puppetserver`, create the
puppet user and group, start the JVM as puppet, and fail to write to
its logfile, due to permissions on the grandparent `logdir`.

This commit changes the `logdir` to `/var/log/puppetlabs/puppet`, so
that puppet can manage permissions on its `logdir` without affecting
puppetserver, or other packages.

Note mcollective.log remains where it is.