### PR TITLE
(packaging) Remove reference to etc/ under app dir for server layout

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -308,13 +308,11 @@ The package will install a service named `puppetserver`, create a
             httpd                         # httpd app dir
                 bin
                     httpd
-                etc
                 lib
 
             puppetserver                  # puppetserver app dir
                 bin
                     puppetserver
-                etc
                 lib
         bin                               # symlinks of server binaries
             httpd@                        -> /opt/puppetlabs/server/apps/httpd/bin/httpd


### PR DESCRIPTION
Under the current plan, server component config files will live in
/etc/puppetlabs/<component> - there will not be a config directory
under /opt/puppetlabs/server/apps/<component>.