### PR TITLE
(PE-9922) Update file paths specification for File Sync service paths

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -32,6 +32,16 @@ The files annotated by an '*' indicate that they are created by package installa
         hiera.yaml *                      # :hiera_config
         modules *                         # user modulepath
 
+    /etc/puppetlabs/code-staging          # staging directory            n/a
+        environments
+          production
+            hieradata
+            environment.conf
+            manifests
+            modules
+        hiera.yaml
+        modules
+
     /etc/puppetlabs/mcollective *
         client.cfg *
         facts.yaml *
@@ -328,6 +338,9 @@ The package will install a service named `puppetserver`, create a
         data
             puppetserver                  # :vardir (and $HOME for services that use it)
                 bucket                    # :bucketdir
+                filesync                  # file sync service datadir
+                  client
+                  storage
                 reports                   # :reportdir
                 server_data               # :server_datadir
                 yaml                      # :yamldir


### PR DESCRIPTION
Add a directory `/etc/puppetlabs/code-staging` which will be the directory
where users will lay down and interact with code if they are using the file
sync service. The File Sync service will then sync this code into the codedir.

Add the File Sync service datadir at
`/opt/puppetlabs/data/puppetserver/filesync`. This is where the File Sync
storage service and client service will keep the git directories they use for
storing data.