### PR TITLE
(PCP-91) MSI omits pxp-module-puppet.conf

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -222,7 +222,7 @@ create a `puppet` user or group.
         etc *
             pxp-agent.conf                    # pxp-agent configuration file
             modules *                         # stores configuration files for pxp-agent modules
-                pxp-module-puppet.conf *      # configuration file of the pxp module puppet
+                pxp-module-puppet.conf        # configuration file of the pxp module puppet
         var *
             log
                 pxp-agent.log                 # enabled by default


### PR DESCRIPTION
 - It was decided that writing a JSON based pxp-module-puppet.conf
   was a difficult proposition for the Windows MSI based on
   that requiring a custom action.  This would have been required
   on Windows since Windows has the ability to relocate the
   binary installation directory.

   However, given that the pathing structure under the top-level
   installation directory is fixed, we can use relative paths to
   assume default values for the pxp-module-puppet "interpreter"
   and "puppet_bin" configuration settings.  The pxp-agent code
   is being modified as such, and therefore the MSI no longer
   needs to lay down a pxp-module-puppet.conf

   Furthermore, on PE, a module will write the appropriate
   configuration settings after initial contact with a master.