### PR TITLE
(PCP-101) Annotate pxp-agent's log and spool directories

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -227,8 +227,6 @@ create a `puppet` user or group.
             log *
                 pxp-agent.log                 # enabled by default
             spool *                            # directory containing results of pxp-agent modules
-            run *
-                pxp-agent.pid
 
     C:\Program Files\Puppet Labs\Puppet
         VERSION                               # puppet-agent package version

--- a/file_paths.md
+++ b/file_paths.md
@@ -130,13 +130,13 @@ The files annotated by an '*' indicate that they are created by package installa
     /opt/puppetlabs/pxp-agent *
         modules *
             pxp-module-puppet *
-        spool                             # directory containing results of pxp-agent modules
+        spool *                            # directory containing results of pxp-agent modules
 
     /var/log/puppetlabs *
         mcollective.log
         puppet *                          # :logdir                      /var/lib/puppet/log
             puppet.log                    # not enabled by default
-        pxp-agent
+        pxp-agent *
             pxp-agent.log                 # enabled by default
 
     /var/run/puppetlabs *                 # :rundir                      /var/lib/puppet/run
@@ -224,10 +224,10 @@ create a `puppet` user or group.
             modules *                         # stores configuration files for pxp-agent modules
                 pxp-module-puppet.conf        # configuration file of the pxp module puppet
         var *
-            log
+            log *
                 pxp-agent.log                 # enabled by default
-            spool                             # directory containing results of pxp-agent modules
-            run
+            spool *                            # directory containing results of pxp-agent modules
+            run *
                 pxp-agent.pid
 
     C:\Program Files\Puppet Labs\Puppet


### PR DESCRIPTION
This commit annotates pxp-agent's log and spool directories
to indicate they are created by package installation.