### PR TITLE
(PUP-5742) Specify the Type Alias expression and type keyword

### DIFF
--- a/language/expressions.md
+++ b/language/expressions.md
@@ -1840,4 +1840,102 @@ Example:
 
 The Selector Expression supports unfold/splat the same way as in Case Expression.
 
+Definition Expressions
+---
+The Puppet Language has several definition expressions:
+
+* Function definition
+* User defied resource dfinition
+* Host Class definition
+* Type Alias defiition
+
+The user defied resource definition and host class definition expressions are specified
+in [Catalog Expressions][2], and function definition in [Puppet Functions][3], and [Function API][4].
+
+### Type Alias Expression
+
+The Type Alias Expression makes it possible to assign a type definition to a type name, and use the new type name as a 100% equivalence to the assigned type.
+
+In this version of the specification, only the case of the initial letter in each name segment
+is significant; MyType is equivalent to MYTYPE, MytYPe, etc. This may change in a later release.
+
+The grammar is:
+
+```
+TypeAliasExpression
+  : 'type' QualifiedReference '=' Expression<Type>
+  ;
+```
+
+Example use:
+
+~~~
+type PositiveInts = Array[Integer[0, default]]
+$a = [1,2,3] ~= PositiveInts
+$b = Array[Integer[0, default] == PositiveInts
+~~~
+
+Would set both `$a` and `$b` to `true`.
+
+Type references are autoloaded from the environment and modules. The autoloading rules are:
+
+* The name of the file must be in lower case.
+* No underscore `_` should be use to separate words in a camel cased name; the file for
+  `MyType` should be `mytype.pp`, not `my_type.pp`.
+* Each namespace segment maps to a directory path with the same name.
+* For a module, the `<module_root>/types` corresponds to the module's namespace.
+* For an environment, the `<env_root>/types` corresponds to the `Environment::` namespace
+* An autoloaded type alias `.pp` file may only contain a single type alias.
+  No other expressions are allowed (comments are).
+* The autoloaded type alias must use the full namespace on the left hand side, e.g.
+  `MyModule::MyType`, or `MyModule::Nested::MyType` for a nested namespace.
+
+
+Type references may be created in any manifest, but this should be avoided as they
+cannot be autoloaded and is affected by the order in which manifests are loaded and evaluated.
+This is mainly supported to enable writing small examples and experimentation.
+
+In general:
+* Type aliases are processed before the rest of the logic in the file.
+* All types are allowed on the RHS, even the alias being defined (this creates
+  a *recursive type*).
+* Recursive types are supported in general, i.e. not only by direct recursion created by
+  using the alias being defined on the RHS.
+
+Example: Type Aliases are defied before evaluation takes place
+
+```
+function foo(MyType $x) {
+  notice $x
+}
+notice foo(42)
+
+type MyType = Integer[42,42]
+```
+
+Examples of recursive types:
+
+```
+type IntegerTree = Array[Variant[Integer, IntegerTree]
+type Mix = Variant[Integer, String, MixedTree]
+type MixedTree = Array[Variant[Mix, MixedTree]]
+
+function integer_tree(IntegerTree $x) {
+  notice $x
+}
+integer_tree( [1, 2, [42, 4], [[[ 5 ]]] ] )
+
+function mixed(MixedTree $x) {
+  notice $x
+}
+mixed( [1, 2, [hello, 4], [[[ 5, deep ]]] ] )
+
+```
+
+Since 4.4.0
+
 [1]: types_values_variables.md#string-tofrom-numeric-conversions
+[2]: catalog-expressions.md
+[3]: puppet-functions.md
+[4]: func-api.md
+

--- a/language/expressions.md
+++ b/language/expressions.md
@@ -1854,7 +1854,8 @@ in [Catalog Expressions][2], and function definition in [Puppet Functions][3], a
 
 ### Type Alias Expression
 
-The Type Alias Expression makes it possible to assign a type definition to a type name, and use the new type name as a 100% equivalence to the assigned type.
+The Type Alias Expression makes it possible to assign a type definition to a type
+name, and use the new type name as a 100% equivalence to the assigned type.
 
 In this version of the specification, only the case of the initial letter in each name segment
 is significant; MyType is equivalent to MYTYPE, MytYPe, etc. This may change in a later release.
@@ -1872,7 +1873,7 @@ Example use:
 ~~~
 type PositiveInts = Array[Integer[0, default]]
 $a = [1,2,3] ~= PositiveInts
-$b = Array[Integer[0, default] == PositiveInts
+$b = Array[Integer[0, default]] == PositiveInts
 ~~~
 
 Would set both `$a` and `$b` to `true`.
@@ -1898,7 +1899,7 @@ This is mainly supported to enable writing small examples and experimentation.
 In general:
 * Type aliases are processed before the rest of the logic in the file.
 * All types are allowed on the RHS, even the alias being defined (this creates
-  a *recursive type*).
+  a *self recursive type*).
 * Recursive types are supported in general, i.e. not only by direct recursion created by
   using the alias being defined on the RHS.
 
@@ -1916,7 +1917,7 @@ type MyType = Integer[42,42]
 Examples of recursive types:
 
 ```
-type IntegerTree = Array[Variant[Integer, IntegerTree]
+type IntegerTree = Array[Variant[Integer, IntegerTree]]
 type Mix = Variant[Integer, String, MixedTree]
 type MixedTree = Array[Variant[Mix, MixedTree]]
 

--- a/language/lexical_structure.md
+++ b/language/lexical_structure.md
@@ -349,11 +349,13 @@ keyword token is produced instead of a `NAME` token. Keywords are case sensitive
 | `define`
 | `else`
 | `elsif`
+| `function`
 | `if`
 | `in`
 | `inherits`
 | `node`
 | `or`
+| `type`
 | `unless`
 
 The semantics of these is described in [Expressions][1].
@@ -362,8 +364,6 @@ The following keywords are considered reserved for future use and should be avoi
 
 | Reserved Words
 | ---
-| `type`
-| `function`
 | `private`
 | `attr`
 
@@ -373,34 +373,36 @@ elements:
 | Reserved Names / Types
 | ---
 | `any, Any`
-| `hash, Hash`
 | `array, Array`
-| `integer, Integer`
-| `float, Float`
-| `collection, Collection`
-| `scalar, Scalar`
-| `resource, Resource`
-| `string, String`
-| `pattern, Pattern`
+| `attr, Attr`
 | `boolean, Boolean`
-| `class, Class`
-| `type, Type`
-| `runtime, Runtime`
-| `numeric, Numeric`
-| `data, Data`
 | `catalogentry, catalogEntry, CatalogEntry`
-| `enum, Enum`
-| `variant, Variant`
+| `class, Class`
+| `collection, Collection`
 | `data, Data`
+| `default, Default`
+| `enum, Enum`
+| `float, Float`
+| `hash, Hash`
+| `integer, Integer`
+| `numeric, Numeric`
+| `object, Object`
+| `optional, Optional`
+| `scalar, Scalar`
+| `pattern, Pattern`
+| `private, Private`
+| `resource, Resource`
+| `runtime, Runtime`
+| `string, String`
 | `struct, Struct`
 | `tuple, Tuple`
-| `optional, Optional`
+| `type, Type`
 | `undef, Undef`
-| `default, Default`
+| `variant, Variant`
 
-While the lower case names are perfectly fine to use (they have no special meaning) when
-using them as names of classes, or user defined defined resource types, the name clashes
-with the built in types (as the lower case name automatically gets an upper cased type reference).
+While the lower case names are perfectly fine to use unless they are also keywords (i.e. when they have no special meaning) they should not be 
+used as names of functions, classes, or user defined defined resource types as the name would clashes
+with the built in types. This occurs because lower case named definitions automatically get an upper cased type reference.
 
 
 Separators / Punctuation

--- a/language/lexical_structure.md
+++ b/language/lexical_structure.md
@@ -400,9 +400,10 @@ elements:
 | `undef, Undef`
 | `variant, Variant`
 
-While the lower case names are perfectly fine to use unless they are also keywords (i.e. when they have no special meaning) they should not be 
-used as names of functions, classes, or user defined defined resource types as the name would clashes
-with the built in types. This occurs because lower case named definitions automatically get an upper cased type reference.
+While the lower case names are perfectly fine to use unless they are also keywords (i.e. when they
+have no special meaning) they should not be  used as names of functions, classes, or user defined
+defined resource types as the name would clashes with the built in types. This occurs because lower
+case named definitions automatically get an upper cased type reference.
 
 
 Separators / Punctuation

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -100,6 +100,24 @@ Optional Typing
 ---
 Typing is optional. When something is not typed, it has the type `Any`.
 
+Type Aliases
+---
+It is possible to create type aliases in the Puppet Programming Language. An aliased type is indistinguishable from the original type.
+
+~~~
+type MyInteger = Integer
+~~~
+
+Recursive Types
+---
+It is possible to create type aliases for recursive types. An alias definition may refer to itself.
+
+~~~
+type IntegerTree = Array[Variant[Integer, IntegerTree]]
+~~~
+
+For more details see the type alias expression.
+
 The Type System
 ===============
 
@@ -718,7 +736,16 @@ $result = $array_of_numbers.reverse_each.step(2).map |$x| { $x * 100 }
 
 Given Example 1, the value of `$result` would be `[300, 200, 100]`.
 
-Note that, in each connection in the chain, there may either be a concrete value, the reverse_each could construct a new `Array` with the elements in reverse order, or it can produce an `Iterator`, that when a new value is pulled from the end of the chain (in the example by `map()`) will calculate which of the values is the next in reverse order, and produce that without requiring an intermediate `Array` to hold the values. View a chain of iterative functions like a pipe-line where values flow through the pipe. Contrast this with transport by tank truck where not a single drop will appear until the truck arrives with the full load.  
+Note that, in each connection in the chain, there may either be a concrete value, the reverse_each could construct a new `Array` with the elements in reverse order, or it can produce an `Iterator`, that when a new value is pulled from the end of the chain (in the example by `map()`) will calculate which of the values is the next in reverse order, and produce that without requiring an intermediate `Array` to hold the values. View a chain of iterative functions like a pipe-line where values flow through the pipe. Contrast this with transport by tank truck where not a single drop will appear until the truck arrives with the full load. 
+
+An Iterator can be transformed to an `Array` by using the unary Unfold Operator (a.k.a splat).
+
+~~~ 
+$a = *[1,2,3].reverse_each
+notice $a =~ Array
+~~~
+
+Will notice `true`.
 
 
 ### Catalog Entry

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -102,7 +102,8 @@ Typing is optional. When something is not typed, it has the type `Any`.
 
 Type Aliases
 ---
-It is possible to create type aliases in the Puppet Programming Language. An aliased type is indistinguishable from the original type.
+It is possible to create type aliases in the Puppet Programming Language. An aliased type is
+indistinguishable from the original type.
 
 ~~~
 type MyInteger = Integer
@@ -123,7 +124,8 @@ The Type System
 
 A type is denoted by an upper cased bare word; e.g. `Integer` (an integer value) optionally followed
 by one or more type parameters enclosed in square brackets `[]`, e.g. `Integer[1,10]` (integer values
-1 to 10 inclusive), or `Array[String[1]]` (an array of non empty strings). See the description of each type for the available type parameters.
+1 to 10 inclusive), or `Array[String[1]]` (an array of non empty strings). See the description of each
+type for the available type parameters.
 
 The type hierarchy is shown in the figure below. (A single capital letter denotes a 
 reference to a type, lower case type parameters have special processing rules as shown


### PR DESCRIPTION
This adds a specification of the Type Alias Expression to
expressions.md

The lexical_structure.md is also updated (basically moving
type from being reserved to a real keyword. In the process, the list of
keywords were sorted.