### PR TITLE
(PUP-5966) Specify new operation

### DIFF
--- a/language/calls.md
+++ b/language/calls.md
@@ -11,7 +11,8 @@ These constructs constitute a call:
   called, this section includes calling/using lambda expressions.
 * **Template Call**, The functions `epp`, and `inline_epp` can pass arguments to template parameters; 
   thus performing a call to the template to produce text.
-* **Instantiation**, creation of resources, resource defaults, resource overrides, and collection.
+* **Resource Instantiation**, creation of resources, resource defaults, resource overrides, and collection.
+* **Instantiation**, creation of values (new objects), conversion of data types etc (Since 4.5.0).
 
 [1]: expressions.md#function-calls
 
@@ -36,7 +37,7 @@ Parameters are always specified in a Parameter List as shown in the following gr
     ParameterList
       : ParameterDeclaration (',' ParameterDeclaration)* ','?
       ;
-      
+
     ParameterDeclaration
       : type = Expression<Type>? 
         vararg ?= '*'?
@@ -98,12 +99,12 @@ parameters are named in this style. In resource creation, resource defaults, and
 overrides, language syntax associates argument names with values - e.g. in a resource expression:
 
     mytype { id1: message => 'hello world' }
-    
+
 the argument `message` is associated with the value 'hello world'. When calling EPP, the arguments
 to the template are specified in a hash.
 
     epp('the_template', { x => 10, y => 20 })
-    
+
 In pass-by-name:
 
 * Only given values that are not `undef` counts as arguments with a value and these values

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -691,6 +691,11 @@ The parameter can be a literal string in which case it is converted into its cor
     Optional[T]  ∪  Undef        → Optional[T]
     Optional[T]  ∪  Optional[R]  → Optional[T ∪ R]
 
+#### Optional[T].new
+
+Since version 4.5.0
+
+Calling `new` on an `Optional[T]` is the same as calling `new` on `T` and then asserting that the result is `T` or `undef`.
 
 ### NotUndef[T]
 
@@ -706,6 +711,12 @@ The parameter can be a literal string in which case it is converted into its cor
     NotUndef[T]  ∪  T            → NotUndef[T]
     NotUndef[T]  ∪  Undef        → Variant[]
     NotUndef[T]  ∪  NotUndef[R]  → NotUndef[T ∪ R]
+
+#### NotUndef[T].new
+
+Since version 4.5.0
+
+Calling `new` on a `NotUndef[T]` is the same as calling `new` on `T` and then asserting that the result is not `undef`.
 
 ### Iterable[T]
 

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -765,6 +765,29 @@ The commonality of two Pattern types is the set operation pattern | pattern:
 
 The types of the boolean expressions `true` and `false`.
 
+#### Boolean.new
+
+Since version 4.5.0
+
+Accepts a single value as argument:
+
+* Float 0.0 is `false`, all other float values are `true`
+* Integer 0 is `false`, all other integer values are `true`
+* Strings
+  * `true` if string is one of 'true', 'yes', or 'y' (case independent compare)
+  * `false` if string is one of 'false', 'no', or 'n' (case independent compare)
+* Boolean is already boolean and is simply returned
+
+Examples of converting to Boolean:
+
+~~~ puppet
+$b2 = Boolean('true')  # true
+$b2 = Boolean('false') # false
+$b1 = Boolean('YEs')   # true
+$b1 = Boolean(0)       # false
+
+~~~
+
 ### Regexp[pattern]
 
 An unparameterized `Regexp` describes the set of all regular expressions. A parameterized `Regexp`

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -861,6 +861,29 @@ any typed arraay that allows *from* to be 0.
     Array[R,a,b] ∪  Array[Q,c,d]  → Array[R ∪ Q, min(a,c), max(b,d)]
     Array[?]     ∪  Hash[?,?]     → Collection
 
+#### Array.new
+
+Since version 4.5.0
+
+When given a single value as argument:
+
+* A non empty `Hash` is converted to an array matching `Array[Tuple[Any,Any], 1]`
+* An empty `Hash` becomes an empty array
+* An `Array` is simply returned
+* An `Iterable[T]` is turned into an array of `T` instances
+
+When given a second Boolean argument
+* if `true`, a value that is not already an array is returned as a one element array
+* if `false`, (the default), converts the first argument as shown above.
+
+Example ensuring value is array
+
+~~~ puppet
+
+$arr = Array($value, true)
+
+~~~
+
 ### Hash[K, V, from, to]
 
 `Hash` represents an ordered collection of associations between a key (of `K` type), and
@@ -970,6 +993,13 @@ The `Tuple` type is a subtype of `Collection`. Its size is specified by the give
 
     Tuple           ∪  Tuple           → Tuple
     Tuple[R, ...]   ∪  Tuple[S, ...]   → Tuple[R ∪ S, ...]
+
+#### Tuple.new
+
+Since version 4.5.0
+
+Conversion to a `Tuple` works exactly as conversion to an `Array` (Array.new), only that the constructed array is
+asserted against the given tuple type.
 
 
 ### Collection[to, from]

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -337,6 +337,52 @@ Iterating over an integer range:
     Integer ∪ (T ∉ Scalar)          → Any
     Integer[a, b] ∪ Integer[c, d]   → Integer[min(a, c), max(b,d)]
 
+#### Integer.new
+
+Since version 4.5.0
+
+A new `Integer` can be created from `Integer`, `Float`, `Boolean`, and `String` values.
+For conversion `from` String it is possible to specify the radix.
+
+Signature:
+
+~~~ puppet
+
+type Radix = Variant[Default, Integer[2,2], Integer[8,8], Integer[10,10], Integer[16,16]]
+type 'NamedArgs   = Struct[{from => Convertible, Optional[radix] => Radix}]'
+Callable[Variant[String, Numeric, Boolean] Radix, 1, 2]
+Callable[NamedArgs]
+
+~~~
+
+* When converting from `String` the default radix is 10
+* If radix is not specified an attempt is made to detect the radix from the start of the string:
+  * `0b` or `0B` is taken as radix 2
+  * `0x` or `0X` is taken as radix 16 
+  * `0` as radix 8
+  * all other are decimal
+* Conversion from `String` accepts an optional sign in the string.
+* For hexadecimal (radix 16) conversion an optional leading "0x", or "0X" is accepted
+* for octal (radix 8) an optional leading "0" is accepted
+* for binary (radix 2) an optional leading "0b" or "0B" is accepted
+* When `radix` is set to `default`, the conversion is based on the leading
+  characters in the string. A leading "0" for radix 8, a leading "0x", or "0X" for
+  radix 16, and leading "0b" or "0B" for binary.
+* Conversion from `Boolean` results in 0 for `false` and 1 for `true`.
+* Conversion from `Integer`, `Float`, and `Boolean` ignores the radix.
+* `Float` value fractions are truncated (no rounding)
+
+Example Converting to Integer
+
+~~~ puppet
+
+$a_number = Integer("0xFF", 16)  # results in 255
+$a_number = Numeric("010")       # results in 8
+$a_number = Numeric("010", 10)   # results in 10
+$a_number = Integer("true")      # results in 1
+
+~~~
+
 ### Float ([from, to])
 
 Represents a range of *inexact* real number values. The default is the range +/- Infinity.

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -272,6 +272,35 @@ Represents the abstract notion of "number", its subtypes are `Integer`, and `Flo
     Numeric ∪ (T ∈ Scalar)     → Scalar
     Numeric ∪ (T ∉ Scalar)     → Any
 
+#### Numeric.new
+
+Since version 4.5.0
+
+A new `Integer` or `Float` can be created from `Integer`, `Float`, `Boolean` and
+`String` values.
+
+~~~ puppet
+
+Callable[Variant[Numeric, Boolean, String]]
+
+~~~
+
+* If the value has a decimal period, or if given in scientific notation
+  (e/E), the result is a `Float`, otherwise the value is an `Integer`.
+* The conversion from `String` always uses a radix based on the prefix of the string.
+* Conversion from Boolean results in 0 for `false` and 1 for `true`.
+
+Example Converting to Numeric
+
+~~~ puppet
+
+$a_number = Numeric("true")  # results in 1
+$a_number = Numeric("0xFF")  # results in 255
+$a_number = Numeric("010")   # results in 8
+$a_number = Numeric("3.14")  # results in 3.14 (a float)
+
+~~~
+
 ### Integer ([from, to])
 
 Represents a range of integral numeric value. The default is the range MIN INTEGER to MAX INTEGER.

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -912,6 +912,17 @@ An empty hash is accepted by any typed hash that allows *from* to be 0.
     Hash[?]       ∪  (T ∈ Collection)   → Collection
     Hash[?]       ∪  (T ∉ Collection)   → Any
 
+#### Hash.new
+
+Since version 4.5.0
+
+Accepts a single value as argument:
+
+* An empty `Array` becomes an empty Hash
+* An `Array` matching `Array[Tuple[Any,Any], 1]` is converted to a hash where each tuple describes a key/value entry
+* An `Array` with an even number of entries is interpreted as `[key1, val1, key2, val2, ...]`
+* An `Iterable` is turned into an `Array` and then converted to Hash as per the array rules
+* A `Hash` is simply returned
 
 ### Struct Type
 
@@ -964,6 +975,13 @@ An unparameterized `Struct` matches all structs and all hashes.
     Struct[{s => T}]     ∪  Hash[K,V]          → Hash[String ∪ K, T ∪ V]
     Struct[?]            ∪  (T ∈ Collection)   → Collection
     Struct[?]            ∪  (T ∉ Collection)   → Any
+
+#### Struct.new
+
+Since version 4.5.0
+
+`Struct.new` works exactly as `Hash.new`, only that the constructed hash is
+asserted against the given struct type.
 
 ### Tuple Type
 

--- a/language/types_values_variables.md
+++ b/language/types_values_variables.md
@@ -437,6 +437,18 @@ You can learn more about floating point than you ever want to know from these ar
     Float ∪ (T ∉ Scalar)        → Any
     Float[a, b] ∪ Float[c, d]   → Float[min(a, c), max(b,d)]
 
+#### Float.new
+
+Since version 4.5.0
+
+A new `Float` can be created from `Integer`, `Float`, `Boolean`, and `String` values.
+For conversion `from` String both float and integer formats are supported.
+
+* For an integer, the floating point fraction of .0 is added to the value.
+* A Boolean true is converted to 1.0, and a false to 0.0
+* In String format, integer prefixes for hex and binary are understood (but not octal since
+  floating point in string format may start with a '0').
+
 ### String([from, to])
 
 Represents a sequence of Unicode characters up to a maximum length of 2^31-1 (the maximum


### PR DESCRIPTION
This adds a specification of the new operation:
* Ability to call a type (general information)
* Specification per type that supports new