### PR TITLE
(PE-10715) Move mcollective logs into their own directory

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -140,7 +140,8 @@ The files annotated by an '*' indicate that they are created by package installa
         spool *                            # directory containing results of pxp-agent modules
 
     /var/log/puppetlabs *
-        mcollective.log
+        mcollective
+            mcollective.log
         puppet *                          # :logdir                      /var/lib/puppet/log
             puppet.log                    # not enabled by default
         pxp-agent *


### PR DESCRIPTION
Prior to this commit, mcollective logs were placed directly in
/var/log/puppetlabs which is the only component to not have
its own directory

After this commit, mcollective logs go in a mcollective directory
