### PR TITLE
(PUP-6934) Update file path specification to include locale directories

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -136,6 +136,7 @@ The files annotated by an '*' indicate that they are created by package installa
                     LC_MESSAGES
                         <project>.mo *    # One directory for each supported locale,
                                           # containing the MO files for each project.
+                                          # Example for English: /opt/puppetlabs/puppet/share/locale/en_US/LC_MESSAGES/puppet.mo
         ssl *
         VERSION                           # puppet-agent package version
 
@@ -302,6 +303,7 @@ create a `puppet` user or group.
                 LC_MESSAGES
                     <project>.mo              # One directory for each supported locale,
                                               # containing the MO files for each project.
+                                              # Example for English: C:\Program Files\Puppet Labs\Puppet\puppet\locale\en_US\LC_MESSAGES\puppet.mo
 
     C:\Program Files\Puppet Labs\Puppet\pxp-agent *
         bin *

--- a/file_paths.md
+++ b/file_paths.md
@@ -298,6 +298,10 @@ create a `puppet` user or group.
         lib *
             puppet.rb *
         locale *
+            <lang_COUNTRY>
+                LC_MESSAGES
+                    <project>.mo              # One directory for each supported locale,
+                                              # containing the MO files for each project.
 
     C:\Program Files\Puppet Labs\Puppet\pxp-agent *
         bin *

--- a/file_paths.md
+++ b/file_paths.md
@@ -131,6 +131,11 @@ The files annotated by an '*' indicate that they are created by package installa
             augeas *
             man *
             vim *
+            locale
+                <lang_COUNTRY>
+                    LC_MESSAGES
+                        <project>.mo *    # One directory for each supported locale,
+                                          # containing the MO files for each project.
         ssl *
         VERSION                           # puppet-agent package version
 
@@ -292,6 +297,7 @@ create a `puppet` user or group.
             puppet *                          # ruby bin wrapper
         lib *
             puppet.rb *
+        locale *
 
     C:\Program Files\Puppet Labs\Puppet\pxp-agent *
         bin *

--- a/file_paths.md
+++ b/file_paths.md
@@ -131,12 +131,14 @@ The files annotated by an '*' indicate that they are created by package installa
             augeas *
             man *
             vim *
-            locale
-                <lang_COUNTRY>
-                    LC_MESSAGES
+            locale *
+                config.yaml *             # configuration file used by the gettext-setup gem
+                <lang_COUNTRY> *
+                    LC_MESSAGES *
                         <project>.mo *    # One directory for each supported locale,
                                           # containing the MO files for each project.
-                                          # Example for English: /opt/puppetlabs/puppet/share/locale/en_US/LC_MESSAGES/puppet.mo
+                                          # Example for English:
+                                          # /opt/puppetlabs/puppet/share/locale/en_US/LC_MESSAGES/puppet.mo
         ssl *
         VERSION                           # puppet-agent package version
 
@@ -298,12 +300,14 @@ create a `puppet` user or group.
             puppet *                          # ruby bin wrapper
         lib *
             puppet.rb *
-        locale *
-            <lang_COUNTRY>
-                LC_MESSAGES
-                    <project>.mo              # One directory for each supported locale,
+        share *
+            locale *
+                config.yaml *                 # configuration file used by the gettext-setup gem
+                <lang_COUNTRY> *
+                    LC_MESSAGES\<project>.mo *# One directory for each supported locale,
                                               # containing the MO files for each project.
-                                              # Example for English: C:\Program Files\Puppet Labs\Puppet\puppet\locale\en_US\LC_MESSAGES\puppet.mo
+                                              # Example for English:
+                                              # C:\Program Files\Puppet Labs\Puppet\puppet\locale\en_US\LC_MESSAGES\puppet.mo
 
     C:\Program Files\Puppet Labs\Puppet\pxp-agent *
         bin *


### PR DESCRIPTION
This adds a specification for the location of translation files for use
with gettext, both on Unix and on Windows.

This PR is in part a request for comment: do these seem like the correct directories for PO files?