### PR TITLE
(PUP-6857) Clarify the role of metadata.json for function loading

### DIFF
--- a/language/func-api.md
+++ b/language/func-api.md
@@ -652,5 +652,10 @@ Manifest loaded functions can define functions in any namespace. This should onl
 
 Nested namespaces are suppoted in the 4.x API for both Ruby and Puppet. The paths to the `.rb` or `.pp` files containing such functions should have each additional namespace in a nested directory. As an example the function `environment::testing::env_func()` should be placed in `<root>/lib/puppet/functions/environment/testing/env_func.rb` (Ruby API), or `<root>/functions/environment/testing/env_func.pp` (Puppet API).
 
+> **Note:** A module that wants to call a function in another module **must** either have
+> that module listed as a dependency, or have no dependencies entry at all in its `metadata.json`.
+> This requirement is enforced at runtime to help users keep meta data for modules up to date
+> as users then simply need to install a module and its dependencies. If a module does not have
+> the correct dependencies listed the runtime will simply not find the function.
 
 [1]: #autoloading

--- a/language/func-api.md
+++ b/language/func-api.md
@@ -654,7 +654,7 @@ Nested namespaces are suppoted in the 4.x API for both Ruby and Puppet. The path
 
 > **Note:** A module that wants to call a function in another module **must** either have
 > that module listed as a dependency, or have no dependencies entry at all in its `metadata.json`.
-> This requirement is enforced at runtime to help users keep meta data for modules up to date
+> This requirement is enforced at runtime to help users keep metadata for modules up to date
 > as users then simply need to install a module and its dependencies. If a module does not have
 > the correct dependencies listed the runtime will simply not find the function.
 


### PR DESCRIPTION
Before this, there was no text in the specification that mentioned that
metadata.json must list another module as a dependency in order for its
functions to be found.

Now this is added last in the section about "autoloading".