### PR TITLE
(BOLT-638) Updates to introduce 'apply' to the Puppet language

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,17 @@ Index
 * [Expressions][7] - specification of all non catalog expressions in the language
 * [Catalog Expressions][8] - specification of all expressions related to catalog production
 * [Expression Precedence][9] - specification of the precedence of expressions / operators
+* [Puppet Functions][14] - functions in the puppet language
 * [Deprecation][10] - specification of deprecated constructs
 * PROPOSALS
-  * [Puppet Functions][14] - functions in the puppet language 
 * API
   * [Function Ruby API][11] - the API for writing functions in Ruby
   * [Plugin Ruby API][12] - the API for plugins in Ruby
   * [Resource Type Ruby API][16] - the API for resource types in Ruby
 * Models
   * [Puppet Extended S-Expression Notation (PN)][17] - specification of the PN format 
+* Plan Extensions
+  * [Apply Expression][18] - an expression to capture a manifest block and apply it on remote nodes
 * General
   * [Settings and Options][13] - specification of settings and options 
   * [Puppet Installation Layout][15] - specification of Puppet related files on disk
@@ -76,5 +78,6 @@ Index
 [15]:file_paths.md
 [16]:language/resource_types.md
 [17]:models/pn.md
+[18]:language/apply.md
 
 [1]:http://www.github.com/puppetlabs/puppet

--- a/language/apply.md
+++ b/language/apply.md
@@ -1,0 +1,34 @@
+Apply Expression
+===
+
+An `ApplyExpression` describes a manifest block which will be compiled to a catalog and applied on remote nodes.
+
+Grammar
+---
+
+    ApplyExpression
+      : 'apply' arguments = ArgumentList '{' statements? '}'
+      ;
+
+    statements
+       # All statements in the Puppet Programming Language (not shown) except NodeDefinition,
+       # ClassDefinition, ResourceTypeDefinition, FunctionDefinition, and exported resource collectors
+       : ...
+       | primary_expression
+
+    primary_expression
+      : ... # all expressions that are primary expression in the Puppet Language (not shown)
+      | epp_render_expression
+
+See [Function Calls](expressions.md#function-calls) for `ArgumentList` grammar definitions.
+
+An `ApplyExpression` takes an argument list of zero or more arguments. The intention is that the 1st
+argument is required, and represents a set of remote nodes to operate on, while the second argument is a hash of
+options. However defining the behavior of an ApplyExpression is out of the scope of this standard.
+
+The statements of an ApplyExpression comprise those statements expected within a manifest or the body of a class,
+excepting statements that themselves define named objects. The scope of statements is considered to be top-scope.
+
+An ApplyExpression may return a value.
+
+ApplyExpression is allowed within a PlanDefinition (to be defined later).

--- a/language/lexical_structure.md
+++ b/language/lexical_structure.md
@@ -403,6 +403,8 @@ The following keywords are considered reserved for future use and should be avoi
 | ---
 | `private`
 | `attr`
+| `plan`
+| `apply`
 
 These names are reserved for types, and are unsuitable as identifiers for other kinds of
 elements:


### PR DESCRIPTION
Introduces the ApplyExpression, reserving `apply` and `plan` as keywords
for future use. Expect to add PlanDefinition docs at a later date.