### PR TITLE
(PUP-8736) Update puppet device paths

### DIFF
--- a/file_paths.md
+++ b/file_paths.md
@@ -77,6 +77,7 @@ Path                                  Setting
     hiera.yaml *                      # :hiera_config
     puppet.conf *                     # :config
     routes.yaml                       # :route_file
+    devices                           # :deviceconfdir
     ssl                               # :ssldir
 
 /etc/puppetlabs/pxp-agent *
@@ -256,6 +257,7 @@ C:\ProgramData\PuppetLabs *
             hiera.yaml *                    # :hiera_config
             puppet.conf *                   # :config
             routes.yaml                     # :route_file
+            devices                         # :deviceconfdir
             ssl *                           # :ssldir
         var *
             log *                           # :logdir


### PR DESCRIPTION
This commit adds aditional puppet device related paths under `confdir`.

Puppet device SSL certs were moved under `deviceconfdir` to avoid certificate loss on backup/restore.

Implementation for this change: https://github.com/puppetlabs/puppet/pull/7612