### PR TITLE
(maint) Update JSON Schema Documents for Tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+---
+dist: xenial
+
+language: ruby
+
+rvm:
+  - 2.5.1
+
+before_install:
+  - cd tests
+
+script:
+  - bundle exec rspec --format documentation
+
+branches:
+  only:
+    - master

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -25,7 +25,7 @@ Task Runners should document which version and revision of the task spec they su
 
 ### Revision history
 
-These are the revisions to this version of the task spec. 
+These are the revisions to this version of the task spec.
 
 **Note**: Bolt generally uses the latest version and revision of the task spec. Puppet Enterprise versions use a specific version and revision of the task spec, indicated in the PE documentation.
 
@@ -117,7 +117,7 @@ The preferred style of the keys should be `snake_case`.
 }
 ```
 
-A JSON schema of metadata accepted by task runners is included in [task.json](task.json). The Puppet Forge also hosts https://forgeapi.puppet.com/schemas/task.json describing requirements for metadata in published modules; the schema for publishing may be more restrictive to ensure published modules are easy to use without reading their implementation.
+A JSON schema of metadata accepted by task runners is included in [task.json](task.json). The Puppet Forge hosts a mirror at https://forgeapi.puppet.com/schemas/task.json.
 
 ## Task parameters
 

--- a/tasks/error.json
+++ b/tasks/error.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",  
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "description": "The format for errors in puppet",
   "type": "object",
   "properties" : {
@@ -16,6 +16,6 @@
       "description": "kind specific data about the error.",
       "type": "object"
     }
-  }
+  },
   "requiredProperties": ["type", "msg"]
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+Gemfile.lock

--- a/tests/Gemfile
+++ b/tests/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Requires Ruby 2.4+
+group :development do
+  gem 'json_schemer', require: false
+  gem 'rspec', require: false
+end

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+PROJECT_ROOT = File.join(__dir__, '..', '..')

--- a/tests/spec/tasks/schema_spec.rb
+++ b/tests/spec/tasks/schema_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'json_schemer'
+require 'net/http'
+
+def read_schema_document(path)
+  JSON.parse(File.open(path, 'rb') { |f| f.read })
+end
+
+def get_uri(url)
+  redirects = 0
+  begin
+    response = Net::HTTP.get_response(URI.parse(url))
+    url = response['location'] if response.is_a?(Net::HTTPRedirection)
+    redirects += 1
+  end while response.is_a?(Net::HTTPRedirection) && redirects < 10
+
+  raise "Reached maximum redirects for #{url}" unless redirects < 10
+  raise "Response from #{url} is not HTTP Status 200: #{response.message}" unless response.is_a?(Net::HTTPOK)
+  response.body
+end
+
+def hyper_schema_for_schema(schema)
+  hyper_schema_uri = schema['$schema']
+  hyper_schema_content = JSON.parse(get_uri(hyper_schema_uri))
+  JSONSchemer.schema(hyper_schema_content)
+end
+
+[
+  { name: 'Tasks',  file: 'task.json'},
+  { name: 'Errors', file: 'error.json'}
+].each do |testcase|
+  context "#{testcase[:name]} schema" do
+    let(:schema_path) { File.join(PROJECT_ROOT, 'tasks', testcase[:file]) }
+    let(:schema_json) { read_schema_document(schema_path) }
+    let(:hyper_schema) { hyper_schema_for_schema(schema_json) }
+
+    it 'is a valid JSON document' do
+      expect { schema_json }.to_not raise_error
+    end
+
+    it 'is a valid JSON Schema document' do
+      expect(hyper_schema.valid?(schema_json)).to be(true)
+    end
+  end
+end
+


### PR DESCRIPTION
Previously the error.json schema file was neither a valid JSON document or even
a valid Schema document.  This commit:

- Adds a missing comma
- Changes the schema specification from default (which is no longer allowed) to
  Draft-06, the same as task.json

---

Previously there was no validation on JSON schema documents in this repository.
Now that the Forge API directly links to this file, it is important that is at
the very least a valid JSON Schema document.

This commit adds a smoke test to validate that the tasks JSON schema documents
are syntatically valid.  This commit also adds a Travis CI configuration file
so that the tests can be run automatically.

---

The Forge API no longer hosts its own copy of the Tasks Schema document and now
proxies from this repository directly [1]

This commit updates the README to reflect this change.

[1] puppetlabs/puppet-forge-api#578