### PR TITLE
Fix use of unknown method .error

### DIFF
--- a/language/resource-api/README.md
+++ b/language/resource-api/README.md
@@ -740,14 +740,14 @@ begin
   result = @apt_key_cmd.run(...)
 
   if result.exitstatus != 0
-    context.error(title, "Failed executing apt-key #{...}")
+    context.err(title, "Failed executing apt-key #{...}")
   else
     context.attribute_changed(title, 'content', nil, content_hash,
       message: "Replaced with content hash #{content_hash}")
   end
   context.changed(title)
 rescue Exception => e
-  context.error(title, e, message: 'Updating failed')
+  context.err(title, e, message: 'Updating failed')
   raise unless e.is_a? StandardError
 end
 ```


### PR DESCRIPTION
The resource_api implements `context.err` but not `context.error` as documented here.